### PR TITLE
resolves #5 export a register function

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -5,6 +5,7 @@
     // only CommonJS-like environments that support module.exports,
     // like Node.
     module.exports = factory;
+    module.exports.register = factory;
   } else if (typeof define === 'function' && define.amd) {
     // AMD. Register a named module.
     define('asciidoctor/docbook', ['asciidoctor'], function () {

--- a/src/template-asciidoctor-docbook.js
+++ b/src/template-asciidoctor-docbook.js
@@ -5,6 +5,7 @@
     // only CommonJS-like environments that support module.exports,
     // like Node.
     module.exports = factory;
+    module.exports.register = factory;
   } else if (typeof define === 'function' && define.amd) {
     // AMD. Register a named module.
     define('asciidoctor/docbook', ['asciidoctor'], function () {

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,5 +1,5 @@
 const asciidoctor = require('@asciidoctor/core')()
-require('../dist/main.js')() // Asciidoctor DocBook
+require('../dist/main.js').register() // Asciidoctor DocBook
 const chai = require('chai')
 const expect = chai.expect
 


### PR DESCRIPTION
The CLI will automatically register the converter when the --require option is used.

Preserve the current export for backward compatibility.